### PR TITLE
fix:add-missing-dep-"inquirer"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "cross-spawn": "^6.0.4",
+    "inquirer": "^3.0.6",
     "ip": "^1.1.5",
     "request": "^2.85.0",
     "request-promise": "^4.2.2",


### PR DESCRIPTION
https://github.com/weexteam/xtoolkit/blob/master/src/installer/index.js#L1

```
~/dev/test weex create abcd
module.js:549
    throw err;
    ^

Error: Cannot find module 'inquirer'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/weex-toolkit/node_modules/_xtoolkit@1.0.5@xtoolkit/lib/installer/index.js:1:80)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
```